### PR TITLE
Advanced features: setting min time delay and max number of buffers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ bbb_pru_adc/resources/*.so
 bbb_pru_adc/resources/*.fw
 gen/firmware*
 *egg-info
+*.pyc
 build
 dist

--- a/bbb_pru_adc/capture.py
+++ b/bbb_pru_adc/capture.py
@@ -88,6 +88,8 @@ def capture(channels, auto_install=False, speed=0, max_num=0, target_delay=0):
         raise ValueError('Speed must be in 0..0xffff')
 
     num_records = (512-16-4) // (4 + 2 * num_channels)
+    if max_num > 0 and max_num < num_records:
+        num_records = max_num
     timestamps = array.array('I', [0] * num_records)
     values = array.array('f', [0.] * (num_records * num_channels))
     num_dropped = c_ushort()

--- a/src/common.h
+++ b/src/common.h
@@ -27,7 +27,7 @@ typedef struct {
     uint16_t  speed;          // 0 - highest speed, 8-lowest
     uint16_t  num_channels;   // 1-8
     uint8_t   channels[8];
-    uint16_t  max_num;        // if non-zero, limits the number of captures per buffer
+    uint32_t  max_num;        // if non-zero, limits the number of captures per buffer
     uint32_t  target_delay;   // target dealy between captures
 } command_start_t;
 

--- a/src/common.h
+++ b/src/common.h
@@ -27,6 +27,8 @@ typedef struct {
     uint16_t  speed;          // 0 - highest speed, 8-lowest
     uint16_t  num_channels;   // 1-8
     uint8_t   channels[8];
+    uint16_t  max_num;        // if non-zero, limits the number of captures per buffer
+    uint32_t  target_delay;   // target dealy between captures
 } command_start_t;
 
 /*

--- a/src/driver.c
+++ b/src/driver.c
@@ -69,7 +69,12 @@ typedef struct {
 } driver_impl_t;
 
 
-driver_t *driver_start(unsigned int speed, unsigned int num_channels, unsigned char const *channels) {
+driver_t *driver_start(unsigned int speed,
+		unsigned int num_channels,
+		unsigned char const *channels,
+		unsigned int max_num,
+		unsigned int target_delay
+) {
 	static driver_impl_t driver;
 	command_start_t command;
 
@@ -90,6 +95,8 @@ driver_t *driver_start(unsigned int speed, unsigned int num_channels, unsigned c
 	for (int i = 0; i < num_channels; i++) {
 		command.channels[i] = channels[i];
 	}
+	command.max_num = max_num;
+	command.target_delay = target_delay;
 
 	/* write data to the payload[] buffer in the PRU firmware. */
 	size_t result = write(driver.dev, &command, sizeof(command));

--- a/src/driver.c
+++ b/src/driver.c
@@ -55,8 +55,12 @@
 
 #define MAX_BUFFER_SIZE			512
 
-int driver_num_records(unsigned int num_channels) {
-    return (512 - 16 - 4) / (4 + 2 * num_channels);
+int driver_num_records(unsigned int num_channels, unsigned int max_num) {
+        int num_records = (512 - 16 - 4) / (4 + 2 * num_channels);
+        if (max_num > 0 && num_records > max_num) {
+                num_records = max_num;
+        }
+        return num_records;
 }
 
 
@@ -80,7 +84,7 @@ driver_t *driver_start(unsigned int speed,
 
 	memset(&driver, '\0', sizeof(driver));
 	driver.num_channels = num_channels;
-	driver.num_records = driver_num_records(num_channels);
+	driver.num_records = driver_num_records(num_channels, max_num);
 	driver.dev = open("/dev/rpmsg_pru30", O_RDWR); // | O_NONBLOCK);
 	if (driver.dev < 0) {
 		fprintf(stderr, "could not open /dev/rpmsg_pru30\n");

--- a/src/driver.h
+++ b/src/driver.h
@@ -10,11 +10,13 @@ typedef struct {
     unsigned char eye[8];
 } driver_t;
 
-extern driver_t *driver_start(unsigned int speed, unsigned int num_channels, unsigned char const *channels);
+extern driver_t *driver_start(unsigned int speed,
+   unsigned int num_channels, unsigned char const *channels,
+   unsigned int max_num, unsigned int target_delay);
 
 extern int driver_read(driver_t *drv, int *num_dropped, unsigned int *timestamps, float *values);
 extern int driver_stop(driver_t *drv);
 
-extern int driver_num_records(unsigned int num_channels);
+extern int driver_num_records(unsigned int num_channels, unsigned int max_num);
 
 #endif

--- a/src/firmware.c
+++ b/src/firmware.c
@@ -460,7 +460,7 @@ void main(void) {
 				while (PRU0_CTRL.CYCLE < target_delay) {}
 				uint32_t cycles = PRU0_CTRL.CYCLE;
 				PRU0_CTRL.CYCLE = 0;
-				send_to_buffer(pio, ring, cycles, values, len);
+				send_to_buffer(pio, ring, cycles, values, len, max_num);
 			}
 		}
 	}

--- a/src/firmware.c
+++ b/src/firmware.c
@@ -444,6 +444,7 @@ void main(void) {
 				command_start_t *start = (command_start_t *) recv_buffer;
 				padc = adc_open(start->speed, start->num_channels, start->channels);
 				max_num = start->max_num;
+				target_delay = start->target_delay;
 				PRU0_CTRL.CYCLE = 0;
 			} else if (padc != NULL && cmd->command == COMMAND_ACK) {
 				ring_release_buffer(ring);  // CPU acknowledged receiving data buffer

--- a/src/firmware.c
+++ b/src/firmware.c
@@ -351,7 +351,6 @@ typedef struct {
 #define RING_SIZE 8
 	uint16_t available;
 	uint16_t head;
-	uint16_t buffer_limit;
 	uint8_t rings[RING_SIZE][MAX_SIZE];
 } ring_t;
 


### PR DESCRIPTION
This implements two new features:

1. Ability to fine-tune the capturing frequency by using `target_delay` parameter, and
2. Limit the number of samples per buffer using the `max_num` parameter.

This code is untested.

@mtkaplanoglu please try building and running it and report any issues here.